### PR TITLE
sysexts.just: Add retry function & use it for VSCodium

### DIFF
--- a/sysext.just
+++ b/sysext.just
@@ -70,6 +70,28 @@ podman_extra_opts := env('JUST_PODMAN_EXTRA_OPTS', '')
 # Default podman options
 podman_opts := "--rm --arch=" + arch + " --security-opt label=disable" + podman_extra_opts
 
+# Define a retry function for use in recipes
+retry_function := '
+retry() {
+    if [[ "${#}" -lt 3 ]]; then
+        echo "retry usage: <number of tries> <time between retries> <command> ..."
+        return 1
+    fi
+    tries="${1}"
+    sleep="${2}"
+    shift 2
+    for i in $(seq 1 ${tries}); do
+        if [[ ${i} -gt 1 ]]; then
+            # echo "[+] Command failed. Waiting for ${sleep} seconds"
+            sleep ${sleep}
+        fi
+        # echo "[+] Running (try: ${i}): ${@}"
+        "${@}" && r=0 && break || r=$?
+    done
+    return $r
+}
+'
+
 # Default, empty, just recipe
 default:
     #!/bin/bash

--- a/vscodium/justfile
+++ b/vscodium/justfile
@@ -23,9 +23,11 @@ download-rpms target arch=arch:
 
     arch="{{arch}}"
 
+    {{retry_function}}
+
     echo "⬇️ Downloading VSCodium"
     url="https://api.github.com/repos/VSCodium/vscodium/releases/latest"
-    curl --fail --silent "${url}" > json
+    retry 5 60  curl --fail --silent "${url}" > json
     release="$(cat json | jq -r '.tag_name')"
     rpmurl="$(cat json | jq -r '.assets[] | select(.name == "codium-'${release}'-el8.'${arch}'.rpm") | .browser_download_url')"
     wget "${rpmurl}"{,.sha256}


### PR DESCRIPTION
sysexts.just: Add retry function as variable

Define a retry bach function in a Just variable for use in recipes.

---

vscodium: Retry downloads to limit flakes in CI

Could be switched to curl native retry options.