### PR TITLE
Contributing Netbird

### DIFF
--- a/.github/workflows/sysexts-fedora.yml
+++ b/.github/workflows/sysexts-fedora.yml
@@ -140,6 +140,18 @@ jobs:
           sysext: 'mullvad-vpn'
           image: ${{ env.IMAGE }}
 
+      - name: "Build sysext: netbird-ui"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'netbird-ui'
+          image: ${{ env.IMAGE }}
+
+      - name: "Build sysext: netbird"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'netbird'
+          image: ${{ env.IMAGE }}
+
       - name: "Build sysext: nordvpn-gui"
         uses: ./.github/actions/build
         with:
@@ -321,6 +333,18 @@ jobs:
         uses: ./.github/actions/build
         with:
           sysext: 'mullvad-vpn'
+          image: ${{ env.IMAGE }}
+
+      - name: "Build sysext: netbird-ui"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'netbird-ui'
+          image: ${{ env.IMAGE }}
+
+      - name: "Build sysext: netbird"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'netbird'
           image: ${{ env.IMAGE }}
 
       - name: "Build sysext: nordvpn-gui"

--- a/netbird-ui/Containerfile
+++ b/netbird-ui/Containerfile
@@ -1,0 +1,9 @@
+FROM baseimage
+
+RUN <<EORUN
+set -xeuo pipefail
+rpm --import https://pkgs.netbird.io/yum/repodata/repomd.xml.key
+echo -e '[netbird]\nname=netbird\nbaseurl=https://pkgs.netbird.io/yum/\nenabled=1\ngpgcheck=0\ngpgkey=https://pkgs.netbird.io/yum/repodata/repomd.xml.key\repo_gpgcheck=1' | tee /etc/yum.repos.d/netbird.repo > /dev/null
+dnf install -y netbird-ui
+dnf clean all
+EORUN

--- a/netbird-ui/README.md
+++ b/netbird-ui/README.md
@@ -1,0 +1,7 @@
+# netbird-ui
+
+Netbird CLI and GUI from the official RPM: https://docs.netbird.io/get-started/install/linux#fedora-amazon-linux-2023-dnf
+
+## Compatibility
+
+This sysext is compatible with Fedora Atomic Desktops.

--- a/netbird-ui/justfile
+++ b/netbird-ui/justfile
@@ -1,0 +1,35 @@
+name := "netbird-ui"
+packages := "netbird-ui"
+pre_commands := "rpm --import https://pkgs.netbird.io/yum/repodata/repomd.xml.key; echo -e '[netbird]\nname=netbird\nbaseurl=https://pkgs.netbird.io/yum/\nenabled=1\ngpgcheck=0\ngpgkey=https://pkgs.netbird.io/yum/repodata/repomd.xml.key\repo_gpgcheck=1' | tee /etc/yum.repos.d/netbird.repo > /dev/null"
+base_images := "
+quay.io/fedora-ostree-desktops/base-atomic:42 x86_64
+quay.io/fedora-ostree-desktops/base-atomic:43 x86_64
+"
+
+import '../sysext.just'
+
+all: default
+
+# Custom version logic as the package file name does not follow the expected convention
+version:
+    #!/bin/bash
+    set -euo pipefail
+    if [[ -n "{{debug}}" ]]; then
+      set -x
+    fi
+
+    package_version() {
+        rpm="${1}"
+        epoch="$(rpm -qp --queryformat '%{EPOCH}' ${rpm})"
+        version="$(rpm -qp --queryformat '%{VERSION}-%{RELEASE}' ${rpm})"
+        if [[ "${epoch}" == "(none)" ]]; then
+            epoch=""
+        else
+            epoch="${epoch}-"
+        fi
+        echo "${epoch}${version}" > ./version
+    }
+
+    echo "🏷️ Writing down version"
+
+    package_version rpms/netbird-ui*.rpm

--- a/netbird/Containerfile
+++ b/netbird/Containerfile
@@ -1,0 +1,9 @@
+FROM baseimage
+
+RUN <<EORUN
+set -xeuo pipefail
+rpm --import https://pkgs.netbird.io/yum/repodata/repomd.xml.key
+echo -e '[netbird]\nname=netbird\nbaseurl=https://pkgs.netbird.io/yum/\nenabled=1\ngpgcheck=0\ngpgkey=https://pkgs.netbird.io/yum/repodata/repomd.xml.key\repo_gpgcheck=1' | tee /etc/yum.repos.d/netbird.repo > /dev/null
+dnf install -y netbird
+dnf clean all
+EORUN

--- a/netbird/README.md
+++ b/netbird/README.md
@@ -1,0 +1,8 @@
+# netbird
+
+Netbird from the official RPM: https://docs.netbird.io/get-started/install/linux#fedora-amazon-linux-2023-dnf
+
+## Compatibility
+
+This sysext is compatible with all Fedora variants (CoreOS, Atomic Desktops,
+etc.).

--- a/netbird/justfile
+++ b/netbird/justfile
@@ -1,0 +1,35 @@
+name := "netbird"
+packages := "netbird"
+pre_commands := "rpm --import https://pkgs.netbird.io/yum/repodata/repomd.xml.key; echo -e '[netbird]\nname=netbird\nbaseurl=https://pkgs.netbird.io/yum/\nenabled=1\ngpgcheck=0\ngpgkey=https://pkgs.netbird.io/yum/repodata/repomd.xml.key\repo_gpgcheck=1' | tee /etc/yum.repos.d/netbird.repo > /dev/null"
+base_images := "
+quay.io/fedora-ostree-desktops/base-atomic:42 x86_64
+quay.io/fedora-ostree-desktops/base-atomic:43 x86_64
+"
+
+import '../sysext.just'
+
+all: default
+
+# Custom version logic as the package file name does not follow the expected convention
+version:
+    #!/bin/bash
+    set -euo pipefail
+    if [[ -n "{{debug}}" ]]; then
+      set -x
+    fi
+
+    package_version() {
+        rpm="${1}"
+        epoch="$(rpm -qp --queryformat '%{EPOCH}' ${rpm})"
+        version="$(rpm -qp --queryformat '%{VERSION}-%{RELEASE}' ${rpm})"
+        if [[ "${epoch}" == "(none)" ]]; then
+            epoch=""
+        else
+            epoch="${epoch}-"
+        fi
+        echo "${epoch}${version}" > ./version
+    }
+
+    echo "🏷️ Writing down version"
+
+    package_version rpms/netbird*.rpm


### PR DESCRIPTION
I would like to contribute Netbird to Fedora Sysexts. Netbird is a Wireguard-based mesh VPN in the style of Tailscale, but it is completely open source and self hostable.

This sysext is based on the official RPM packages provided by the Netbird team: https://docs.netbird.io/get-started/install/linux#fedora-amazon-linux-2023-dnf netbird is the cli client, and netbird-ui is the GUI client (actually an appindicator based systray app). I have been building the systexts for me and using them for weeks to test. The appindicator seems to have a weird behavior where submenus don't stay open, but that happens also with the normal RPM, so I guess it's a bug of the application itself

I tried to follow the other sysexts as much as possible. Please let me know if you are interested and if any changes need to be made. Thanks for the great work.

NOTE: The netbird RPM packages have a non-standard <name>_<version> name, as opposed to <name-version>. This required a change to the regexes that extract the version information  in the `systext.just` file. I tried building a few other sysexts and my change seems back-compatile. I hope it is not too intrusive