### PR TITLE
Add cursor sysext

### DIFF
--- a/.github/workflows/sysexts-fedora.yml
+++ b/.github/workflows/sysexts-fedora.yml
@@ -92,6 +92,12 @@ jobs:
           sysext: 'cloud-hypervisor'
           image: ${{ env.IMAGE }}
 
+      - name: "Build sysext: cursor"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'cursor'
+          image: ${{ env.IMAGE }}
+
       - name: "Build sysext: dnclient"
         uses: ./.github/actions/build
         with:
@@ -281,6 +287,12 @@ jobs:
           sysext: 'cloud-hypervisor'
           image: ${{ env.IMAGE }}
 
+      - name: "Build sysext: cursor"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'cursor'
+          image: ${{ env.IMAGE }}
+
       - name: "Build sysext: dnclient"
         uses: ./.github/actions/build
         with:
@@ -440,6 +452,12 @@ jobs:
           sysext: 'cloud-hypervisor'
           image: ${{ env.IMAGE }}
 
+      - name: "Build sysext: cursor"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'cursor'
+          image: ${{ env.IMAGE }}
+
       - name: "Build sysext: dnclient"
         uses: ./.github/actions/build
         with:
@@ -549,6 +567,12 @@ jobs:
         uses: ./.github/actions/build
         with:
           sysext: 'cloud-hypervisor'
+          image: ${{ env.IMAGE }}
+
+      - name: "Build sysext: cursor"
+        uses: ./.github/actions/build
+        with:
+          sysext: 'cursor'
           image: ${{ env.IMAGE }}
 
       - name: "Build sysext: dnclient"

--- a/cursor/Containerfile
+++ b/cursor/Containerfile
@@ -1,0 +1,9 @@
+FROM baseimage
+
+RUN <<EORUN
+set -xeuo pipefail
+rpm --import https://downloads.cursor.com/keys/anysphere.asc
+echo -e '[cursor]\nname=Cursor\nbaseurl=https://downloads.cursor.com/yumrepo\nenabled=1\ngpgcheck=1\ngpgkey=https://downloads.cursor.com/keys/anysphere.asc' | tee /etc/yum.repos.d/cursor.repo > /dev/null
+dnf install -y cursor
+dnf clean all
+EORUN

--- a/cursor/README.md
+++ b/cursor/README.md
@@ -1,0 +1,5 @@
+# Cursor
+
+[Cursor](https://cursor.com/) is an AI-powered code editor.
+
+This sysext installs Cursor from the official Cursor repository.

--- a/cursor/justfile
+++ b/cursor/justfile
@@ -1,0 +1,7 @@
+name := "cursor"
+packages := "cursor"
+pre_commands := "rpm --import https://downloads.cursor.com/keys/anysphere.asc; echo -e '[cursor]\nname=Cursor\nbaseurl=https://downloads.cursor.com/yumrepo\nenabled=1\ngpgcheck=1\ngpgkey=https://downloads.cursor.com/keys/anysphere.asc' | tee /etc/yum.repos.d/cursor.repo > /dev/null"
+
+import '../sysext.just'
+
+all: default


### PR DESCRIPTION
Add Cursor, an AI-powered code editor.

This sysext installs Cursor from the official Cursor yum repository at https://downloads.cursor.com/yumrepo

- Supports both x86_64 and aarch64 architectures
- Tested locally, builds successfully